### PR TITLE
Introducing early idea of constraints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 A Rust implementation of [GENtle](https://github.com/GENtle-persons/gentle-m).
 
+## Shell Interface
+
 One of the upcoming features of that new implmentation shall be an extension
 of the graphical user interface with a shell.
 
-## JavaScript interactive shell
+### JavaScript interactive shell
 You can run GENtle as an interactive shell using JavaScript.
 
-### Example
+#### Example
 ```
 > cargo run --release --bin gentle_js
 Interactive JavaScript Shell (type 'exit' to quit)
@@ -24,10 +26,10 @@ GENtle> console.log(results[1].seq.seq.length) // Length of second sequence
 4938
 ```
 
-## Lua interactive shell
+### Lua interactive shell
 You can run GENtle as an interactive shell using the [Lua programming language](https://www.lua.org/).
 
-### Example
+#### Example
 ```
 > cargo run --release --bin gentle_lua
 Interactive Lua Shell (type 'exit' to quit)
@@ -42,7 +44,40 @@ GENtle> pgex.methylation_sites -- shows the precomputed methylation_sites
 GENtle> write_gb("output.gb",pgex) -- writes the sequence to a new GenBank file
 ```
 
-## Install
+### Vision: Declarative Cloning
+
+The interaction with a cloning too is a bit ambivalent. If you know exactly what you want then you can just look up the sequences in a
+database - and frankly this is how many are still doing it. The cloning tool then only comes in afterwards to generate graphics to
+explain what you have done to your peers.
+
+If however you do not know what to do, the a graphical representation is of little help since there are too many options for your single
+mouse pointer and your single brain to process. And filters alone may not come at your rescue. This especially
+holds for more complicated serial cloning events, when one change in the first step (say adjusting the coding frequencies to another species)
+may downstream affect the primers or endonucleases to select.
+
+What we are anticipating, without yet an exact plan how to implement it, is to have GENtle offering a series of core operations, and then derive cloning templates from them.
+The exact protocol is then constituted by the order of these operations (which could be a template), and what would traditionally be
+offered as a manual filter in a dialog box, may be automated as a set of user-driven constraints.
+For instance, a core feature could be to derive a subsequence from a given sequence or its inverse complement.
+And there could be a function to determine the annealing temperature of any sequence.
+Then a PCR can be derived as getting two of these subsequences, but with constraints, roughly like the following:
+ * different strands
+ * lengths of oligos between 16 and 22
+ * annealing temperature within 2 degrees of each other
+ * region of interest between primer positions
+and depending on the experimental setup it may be required to also demand
+ * Genomic uniqueness of primers / primer pairing
+
+Essentially, the idea is to express in writing (and likely with some support by the GUI) what you want to be cloned and then GENtle should figure out how it is to be done. 
+The above mentioned PCR scenario is implemented in src/constraints.rs. For an early look at how JSON-formatted constraint could be used to direct the cloning, and to think along, please run
+
+```bash
+cargo test constraints
+```
+
+
+
+## Installation
 
 - [Install Rust](https://www.rust-lang.org/tools/install)
 ```bash

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -323,7 +323,7 @@ mod tests {
     "min_temp": 3,
     "max_temp": 7
 }
-"#;        
+"#;
         // Parse JSON into a PrimerPairConstraint struct
         let pair_constraint: PrimerPairConstraint = serde_json::from_str(primer_pair_constraint_json)?;
         // Print parsed constraints for verification

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -1,0 +1,409 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+
+#[derive(Deserialize, Debug)]
+pub struct PrimerConstraint {
+    min_length: usize,
+    max_length: usize,
+    location: Option<usize>, // Optional specific start location
+}
+
+impl PrimerConstraint {
+    pub fn new(min_length: usize, max_length: usize, location: Option<usize>) -> Self {
+        PrimerConstraint {
+            min_length,
+            max_length,
+            location,
+        }
+    }
+}
+
+/*
+impl FromStr for PrimerConstraint {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut min_length = None;
+        let mut max_length = None;
+        let mut location = None;
+
+        for part in s.split(',') {
+            let trimmed = part.trim();
+            if trimmed.starts_with("min_length=") {
+                min_length = trimmed["min_length=".len()..].parse().ok();
+            } else if trimmed.starts_with("max_length=") {
+                max_length = trimmed["max_length=".len()..].parse().ok();
+            } else if trimmed.starts_with("location=") {
+                location = trimmed["location=".len()..].parse().ok();
+            }
+        }
+
+        Ok(PrimerConstraint {
+            min_length: min_length.ok_or("Missing min_length")?,
+            max_length: max_length.ok_or("Missing max_length")?,
+            location,
+        })
+    }
+}
+*/
+
+#[derive(Deserialize, Debug)]
+pub struct PrimerPairConstraint {
+    forward: PrimerConstraint,
+    reverse: PrimerConstraint,
+    from: usize,                  // Start of the area to cover
+    to: usize,                    // End of the area to cover
+    max_product_size: usize,      // Maximum allowed product size
+    min_temp: Option<usize>,      // Minimum annealing temperature (optional)
+    max_temp: Option<usize>,      // Maximum annealing temperature (optional)
+}
+
+/*
+impl FromStr for PrimerPairConstraint {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut forward_constraint = None;
+        let mut reverse_constraint = None;
+        let mut from = None;
+        let mut to = None;
+        let mut max_product_size = None;
+        let mut min_temp = None;
+        let mut max_temp = None;
+
+        for part in s.split(',') {
+            let trimmed = part.trim();
+
+            if trimmed.starts_with("forward") {
+                let fwd_text = trimmed["forward=".len()..].trim();
+                forward_constraint = Some(fwd_text.parse::<PrimerConstraint>().map_err(|e| e.to_string())?);
+            } else if trimmed.starts_with("reverse") {
+                let rev_text = trimmed["reverse=".len()..].trim();
+                reverse_constraint = Some(rev_text.parse::<PrimerConstraint>().map_err(|e| e.to_string())?);
+            } else if trimmed.starts_with("from=") {
+                from = trimmed["from=".len()..].parse().ok();
+            } else if trimmed.starts_with("to=") {
+                to = trimmed["to=".len()..].parse().ok();
+            } else if trimmed.starts_with("max_product_size=") {
+                max_product_size = trimmed["max_product_size=".len()..].parse().ok();
+            } else if trimmed.starts_with("min_temp=") {
+                min_temp = trimmed["min_temp=".len()..].parse().ok();
+            } else if trimmed.starts_with("max_temp=") {
+                max_temp = trimmed["max_temp=".len()..].parse().ok();
+            }
+        }
+
+        Ok(PrimerPairConstraint {
+            forward_constraint: forward_constraint.ok_or("Missing forward primer constraint")?,
+            reverse_constraint: reverse_constraint.ok_or("Missing reverse primer constraint")?,
+            from: from.ok_or("Missing from constraint")?,
+            to: to.ok_or("Missing to constraint")?,
+            max_product_size: max_product_size.ok_or("Missing max_product_size constraint")?,
+            min_temp,
+            max_temp,
+        })
+    }
+}
+*/
+
+pub fn count_occurrences(sequence: &str, primer: &str) -> usize {
+    sequence.matches(primer).count()
+}
+
+// Function to estimate "melting temperature" based on GC content
+pub fn estimate_melting_temp(primer: &str) -> usize {
+    primer.chars().filter(|&c| c == 'G' || c == 'C').count()
+}
+
+// Reverse complement function
+pub fn reverse_complement(dna: &str) -> String {
+    dna.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'T' => 'A',
+            'C' => 'G',
+            'G' => 'C',
+            _ => c,
+        })
+        .collect()
+}
+
+// Generate primers for a specific constraint
+pub fn generate_primers(sequence: &str, constraint: &PrimerConstraint) -> Vec<String> {
+    let mut primers = Vec::new();
+    for start in 0..sequence.len() {
+        if let Some(location) = constraint.location {
+            if start != location {
+                continue;
+            }
+        }
+        for len in constraint.min_length..=constraint.max_length {
+            if start + len <= sequence.len() {
+                primers.push(sequence[start..start + len].to_string());
+            }
+        }
+    }
+    primers
+}
+
+// Generate valid primer pairs based on pair constraints
+pub fn generate_primer_pairs(sequence: &str, pair_constraint: &PrimerPairConstraint) -> Vec<(String, String)> {
+    let mut primer_pairs = Vec::new();
+
+    // Generate the reverse complement of the entire sequence
+    let reverse_sequence = reverse_complement(sequence);
+
+    let forward_primers = generate_primers(sequence, &pair_constraint.forward);
+    let reverse_primers = generate_primers(sequence, &pair_constraint.reverse)
+        .into_iter()
+        .map(|s| reverse_complement(&s))  // Get reverse complement of each reverse primer
+        .collect::<Vec<_>>();
+
+    for forward_primer in &forward_primers {
+        let forward_len = forward_primer.len();
+        let forward_temp = estimate_melting_temp(forward_primer);
+
+        // Ensure forward primer is unique in the sequence
+        if count_occurrences(sequence, forward_primer) != 1 {
+            continue;
+        }
+
+        for reverse_primer in &reverse_primers {
+            let reverse_len = reverse_primer.len();
+            let reverse_temp = estimate_melting_temp(reverse_primer);
+
+            // Ensure reverse primer is unique in the reverse complement sequence
+            if count_occurrences(&reverse_sequence, reverse_primer) != 1 {
+                continue;
+            }
+
+            // Check primer length difference constraint (within 2 nucleotides)
+            if (forward_len as isize - reverse_len as isize).abs() > 2 {
+                continue;
+            }
+
+            // Check approximate melting temperature similarity (within 1 GC count)
+            if (forward_temp as isize - reverse_temp as isize).abs() > 1 {
+                continue;
+            }
+
+            // Check optional min and max temperature constraints
+            if let Some(min_temp) = pair_constraint.min_temp {
+                if forward_temp < min_temp || reverse_temp < min_temp {
+                    continue;
+                }
+            }
+            if let Some(max_temp) = pair_constraint.max_temp {
+                if forward_temp > max_temp || reverse_temp > max_temp {
+                    continue;
+                }
+            }
+
+            // Ensure forward and reverse primers meet product size constraint
+            let fwd_start = sequence.find(forward_primer).unwrap();
+            let rev_start = reverse_sequence.find(reverse_primer).unwrap();
+            let product_size = (rev_start + reverse_len) + fwd_start;
+
+            if product_size <= pair_constraint.max_product_size {
+                primer_pairs.push((forward_primer.clone(), reverse_primer.clone()));
+            }
+        }
+    }
+
+    primer_pairs
+}
+
+/*
+ * Cleavage
+ */
+
+
+#[derive(Deserialize, Debug)]
+struct CleavageConstraint {
+    enzyme: String,           // Enzyme name (e.g., "EcoRI")
+    site: String,             // Recognition site (e.g., "GAATTC")
+    allow: bool               // Whether to allow cleavage at this site
+}
+
+#[derive(Deserialize, Debug)]
+struct CleavageSiteConstraint {
+    enzymes: Vec<CleavageConstraint>,  // List of enzyme-specific constraints
+    from: Option<usize>,               // Start of region to consider
+    to: Option<usize>,                 // End of region to consider
+}
+
+// Function to find cleavage sites in the sequence based on the given constraints
+fn find_cleavage_sites(sequence: &str, constraint: &CleavageSiteConstraint) -> HashMap<String, Vec<usize>> {
+    let mut cleavage_sites: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for enzyme in &constraint.enzymes {
+        let mut sites = Vec::new();
+        let mut start = 0;
+
+        while let Some(pos) = sequence[start..].find(&enzyme.site) {
+            let abs_pos = start + pos;
+            start = abs_pos + 1;
+
+            // Only add the site if allowed
+            if enzyme.allow {
+                sites.push(abs_pos);
+            }
+        }
+
+        if !sites.is_empty() {
+            cleavage_sites.insert(enzyme.enzyme.clone(), sites);
+        }
+    }
+
+    cleavage_sites
+}
+
+// Function to find the closest enzyme sites to a region of interest (ROI)
+fn closest_cleavage_sites(sequence: &str, constraint: &CleavageSiteConstraint, roi_start: usize, roi_end: usize) -> HashMap<String, Option<(usize, usize)>> {
+    let cleavage_sites = find_cleavage_sites(sequence, constraint);
+    let mut closest_sites: HashMap<String, Option<(usize, usize)>> = HashMap::new();
+
+    for (enzyme, sites) in cleavage_sites {
+        let mut closest_start = None;
+        let mut closest_end = None;
+        let mut min_start_dist = usize::MAX;
+        let mut min_end_dist = usize::MAX;
+
+        for &site in &sites {
+            let start_dist = if site <= roi_start { roi_start - site } else { site - roi_start };
+            let end_dist = if site <= roi_end { roi_end - site } else { site - roi_end };
+
+            if start_dist < min_start_dist {
+                min_start_dist = start_dist;
+                closest_start = Some(site);
+            }
+            if end_dist < min_end_dist {
+                min_end_dist = end_dist;
+                closest_end = Some(site);
+            }
+        }
+
+        closest_sites.insert(enzyme, Some((closest_start.unwrap_or(roi_start), closest_end.unwrap_or(roi_end))));
+    }
+
+    closest_sites
+}
+
+
+
+
+/*
+ * Tests
+ */
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_constraints() -> Result<(), Box<dyn std::error::Error>> {
+        // Sample DNA sequence
+        let sequence = "ATGCGTACGTTAGCTAGCTTACGGTAGCTAG";
+        let primer_pair_constraint_json = r#"
+{
+    "forward": {
+        "min_length": 5,
+        "max_length": 10,
+        "location": 3
+    },
+    "reverse": {
+        "min_length": 5,
+        "max_length": 10
+    },
+    "from": 3,
+    "to": 20,
+    "max_product_size": 100,
+    "min_temp": 3,
+    "max_temp": 7
+}
+"#;        
+        // Parse JSON into a PrimerPairConstraint struct
+        let pair_constraint: PrimerPairConstraint = serde_json::from_str(primer_pair_constraint_json)?;
+        // Print parsed constraints for verification
+        println!("{:?}", pair_constraint);
+
+        // Generate primer pairs based on constraints
+        let primer_pairs = generate_primer_pairs(sequence, &pair_constraint);
+
+        println!("Generated primer pairs:");
+        for (forward, reverse) in &primer_pairs {
+            println!("Forward: {}, Reverse: {}", forward, reverse);
+        }
+
+        // Test primer pair generation
+        assert!(!primer_pairs.is_empty());
+        Ok(())
+    }
+
+    fn test_helper_functions() {
+        let sequence = "ATGCGTACGTTAGC";
+        // Test individual functions
+        assert_eq!(count_occurrences(sequence, "ATGC"), 1);
+        assert_eq!(estimate_melting_temp("GCGT"), 3);
+        assert_eq!(reverse_complement("ATGC"), "GCAT");
+
+        // Test primer generation
+        let primers = generate_primers(sequence, &PrimerConstraint::new(5, 10, None));
+        assert!(!primers.is_empty());
+
+    }
+
+    // Cleavage
+
+    #[test]
+    fn test_cleavage_constraints() -> Result<(), Box<dyn std::error::Error>> {
+        // Sample DNA sequence
+        let sequence = "ATGCGTACGTTAGCTAGAATTCTAGTACCGGATCCAGCTAGTGAATTCGTAGGATCC";
+
+        // JSON input defining enzymes and constraints
+        let cleavage_constraint_json = r#"
+        {
+            "enzymes": [
+                {
+                    "enzyme": "EcoRI",
+                    "site": "GAATTC",
+                    "allow": true
+                },
+                {
+                    "enzyme": "BamHI",
+                    "site": "GGATCC",
+                    "allow": true
+                }
+            ],
+            "from": 0,
+            "to": 60
+        }
+        "#;
+
+        // Parse JSON into CleavageSiteConstraint struct
+        let constraint: CleavageSiteConstraint = serde_json::from_str(cleavage_constraint_json)?;
+
+        // Define the Region of Interest (ROI)
+        let roi_start = 20;
+        let roi_end = 40;
+
+        // Find the closest cleavage sites to the ROI
+        let closest_sites = closest_cleavage_sites(sequence, &constraint, roi_start, roi_end);
+
+        // Print results for verification
+        println!("Closest cleavage sites to the ROI ({}, {}):", roi_start, roi_end);
+        for (enzyme, sites) in closest_sites {
+            if let Some((closest_start, closest_end)) = sites {
+                println!("Enzyme: {}, Closest Start: {}, Closest End: {}", enzyme, closest_start, closest_end);
+            } else {
+                println!("Enzyme: {}, No cleavage sites found near ROI", enzyme);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use translations::Translations;
 
 pub mod amino_acids;
 pub mod app;
+pub mod constraints;
 pub mod dna_display;
 pub mod dna_marker;
 pub mod dna_sequence;


### PR DESCRIPTION
Putting this up as an early draft. I do not yet know for sure where this is going to take us.

* Provided an approach for an automated selection for a PCR.
  - define (or do not define) regions of interest for either primer
  - request melting temperatures to be in a similar range
  - ...
* Started with something analogous for restriction enzyme selection
* And now that we have them this could also include PSSM matches
* And any other feature of the DNA sequence

We can now have additional constraints that use those lower-level constraints, like that a primer pair must ensure that an restriction enzyme exists that matches exactly once. And that target sequence shall be upstream of the coding sequence. And the enzyme cut blunt - or have an overhang like ...

I am not ultimately sure where I would want the logic to reside. There are several prolog crates available which may (or may be not) be a nice fit.
